### PR TITLE
chore: harden build/CI pipeline and add binary verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: ci
+name: CI
 
 on:
   push:
@@ -15,15 +15,43 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-24.04
+    name: changes
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Filter changed paths
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!**/*.md'
+              - '!LICENSE'
+              - '!.gitignore'
+              - '!.dockerignore'
+
   docker-image-test:
 
     runs-on: ubuntu-24.04
     name: docker-image-test
+    needs: [changes]
+    if: ${{ needs.changes.outputs.code == 'true' || github.ref_type == 'tag' }}
     timeout-minutes: 30
 
     steps:
 
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
@@ -49,10 +77,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
 
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
@@ -65,18 +94,18 @@ jobs:
 
       - name: Convert owner to lower case
         run: |
-          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+          echo "OWNER_LC=${OWNER,,}" >> "${GITHUB_ENV}"
         env:
           OWNER: '${{ github.repository_owner }}'
 
-      - name: Login to image repository
+      - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker builder meta
+      - name: Docker metadata
         id: meta_builder
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
@@ -106,10 +135,19 @@ jobs:
           platforms: linux/amd64
           push: true
           provenance: false
+          sbom: false
           tags: ${{ steps.meta_builder.outputs.tags }}
           labels: ${{ steps.meta_builder.outputs.labels }}
           cache-from: type=gha,scope=builder
           cache-to: type=gha,mode=max,scope=builder
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign builder image (keyless)
+        env:
+          DIGEST: ${{ steps.docker_builder.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/${OWNER_LC}/quadmath-cross@${DIGEST}"
 
       - name: Output docker_builder image digest
         env:
@@ -128,10 +166,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
 
     steps:
 
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           fetch-depth: 0
@@ -144,18 +183,18 @@ jobs:
 
       - name: Convert owner to lower case
         run: |
-          echo "OWNER_LC=${OWNER,,}" >>${GITHUB_ENV}
+          echo "OWNER_LC=${OWNER,,}" >> "${GITHUB_ENV}"
         env:
           OWNER: '${{ github.repository_owner }}'
 
-      - name: Login to image repository
+      - name: Log in to GHCR
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Docker runtime meta
+      - name: Docker metadata
         id: meta_runtime
         uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
         with:
@@ -176,6 +215,40 @@ jobs:
             io.artifacthub.package.maintainers=[{"name":"Andriy Kalashnykov","email":"andriykalashnykov@gmail.com"}]
             io.artifacthub.package.license=MIT
 
+      # Build the amd64 runtime locally first so it can be scanned and smoke
+      # tested before any multi-arch push to the registry.
+      - name: Build runtime image (amd64, for scan and smoke test)
+        id: build_local
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        with:
+          context: .
+          file: ./Dockerfile.runtime
+          platforms: linux/amd64
+          load: true
+          push: false
+          provenance: false
+          sbom: false
+          build-args: |
+            BUILDER_IMAGE=ghcr.io/${{ env.OWNER_LC }}/quadmath-cross:${{ github.ref_name }}-builder
+          tags: ghcr.io/${{ env.OWNER_LC }}/quadmath-cross:runtime-scan
+          cache-from: type=gha,scope=runtime
+          cache-to: type=gha,mode=max,scope=runtime
+
+      - name: Trivy image scan (CRITICAL/HIGH blocking)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/${{ env.OWNER_LC }}/quadmath-cross:runtime-scan
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Smoke test runtime image
+        run: |
+          out="$(docker run --rm "ghcr.io/${OWNER_LC}/quadmath-cross:runtime-scan" /app/qm-x86_64)"
+          echo "$out"
+          echo "$out" | grep -q '1.41421356237309504880' \
+            || { echo "Smoke test failed: qm-x86_64 did not print sqrt(2)."; exit 1; }
+
       - name: Build and push runtime
         id: docker_runtime
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
@@ -185,12 +258,40 @@ jobs:
           platforms: linux/arm64,linux/amd64
           push: true
           provenance: false
+          sbom: false
+          build-args: |
+            BUILDER_IMAGE=ghcr.io/${{ env.OWNER_LC }}/quadmath-cross:${{ github.ref_name }}-builder
           tags: ${{ steps.meta_runtime.outputs.tags }}
           labels: ${{ steps.meta_runtime.outputs.labels }}
           cache-from: type=gha,scope=runtime
           cache-to: type=gha,mode=max,scope=runtime
 
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign runtime image (keyless)
+        env:
+          DIGEST: ${{ steps.docker_runtime.outputs.digest }}
+        run: cosign sign --yes "ghcr.io/${OWNER_LC}/quadmath-cross@${DIGEST}"
+
       - name: Output docker_runtime image digest
         env:
           DIGEST: ${{ steps.docker_runtime.outputs.digest }}
         run: echo "$DIGEST"
+
+  ci-pass:
+    if: always()
+    runs-on: ubuntu-24.04
+    name: ci-pass
+    needs: [ changes, docker-image-test ]
+    timeout-minutes: 5
+    steps:
+      - name: Verify required jobs succeeded
+        run: |
+          echo "changes=${{ needs.changes.result }} docker-image-test=${{ needs.docker-image-test.result }}"
+          if [ "${{ contains(needs.*.result, 'failure') }}" = "true" ] \
+             || [ "${{ contains(needs.*.result, 'cancelled') }}" = "true" ]; then
+            echo "A required job failed or was cancelled."
+            exit 1
+          fi
+          echo "All required jobs passed or were skipped."

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,5 @@
+# mise — cross-language tool versions (https://mise.jdx.dev).
+# Node.js is required only by `make renovate-validate` (runs `npx renovate`).
+# Tracked by Renovate's `mise` manager.
+[tools]
+node = "24"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,9 @@ make clean             # Remove build artifacts
 make setup-binfmt      # Setup Docker binfmt for arm64 emulation on x86_64 (one-time)
 make cross-compile     # Cross-compile helloworld.c for x86_64, arm, aarch64 (requires local cross-compilers)
 make lint              # Lint all Dockerfiles with hadolint
-make ci                # Full local CI pipeline (lint + build)
+make trivy-fs          # Scan repo for vulnerabilities + secrets with trivy
+make smoke             # Run every compiled binary + assert output (arm64 via QEMU)
+make ci                # Full local CI pipeline (lint + trivy-fs + build + smoke)
 make ci-run            # Run GitHub Actions workflow locally via act
 make version           # Print current git tag version
 make release           # Interactive: create and push a new git tag
@@ -39,10 +41,19 @@ make renovate-validate # Validate Renovate configuration
    - QEMU user-static for running cross-compiled binaries
    - cppcheck static analysis runs before compilation (own sources only; `float128_example.cpp` excluded as third-party Boost example)
    - Compiles all C/C++ sources into statically-linked binaries at build time
+   - **Behavioral verification**: after compilation, every binary is executed and its output asserted (arm64 via `qemu-aarch64-static`, no binfmt needed since binaries are static). A broken artifact fails the image build. `make smoke` repeats these assertions against the built images and is folded into `make ci`.
 
-2. **Runtime image** (`Dockerfile.runtime` / `Dockerfile.runtime.local`) - Alpine with only the compiled binaries:
-   - `Dockerfile.runtime` pulls builder from `ghcr.io` (used in CI)
-   - `Dockerfile.runtime.local` pulls builder from local Docker (used with `make build`)
+2. **Runtime image** (`Dockerfile.runtime` / `Dockerfile.runtime.local`) - Alpine with only the compiled binaries. Both take an `ARG BUILDER_IMAGE` so the builder reference is supplied at build time:
+   - `Dockerfile.runtime` (CI): the `docker-image-runtime` job passes `BUILDER_IMAGE=ghcr.io/<owner>/quadmath-cross:${tag}-builder`, so the runtime always pulls the exact builder for the release being built.
+   - `Dockerfile.runtime.local` (`make build`): `make build` passes the just-built local `docker.io/$(DOCKER_ORG)/quadmath-cross:<tag>-builder`.
+   - The `ARG` default in each file is only a fallback for a bare `docker build` without `--build-arg`.
+
+### Two registries (local vs CI)
+
+- **Local** (`make build`): tags images `docker.io/$(DOCKER_ORG)/quadmath-cross:<tag>-builder` / `-runtime` (overridable via `DOCKER_REGISTRY` / `DOCKER_ORG`); never touches ghcr.io.
+- **CI** (tag push): publishes both images to `ghcr.io/<owner>/quadmath-cross`, Trivy-scanned + smoke-tested and cosign-signed.
+
+Because the builder reference is a build-arg derived from the release tag, there is **no manual `FROM`-tag bump** when cutting a release.
 
 ### Source Files
 
@@ -66,12 +77,14 @@ make renovate-validate # Validate Renovate configuration
 
 ### Main workflow: `.github/workflows/ci.yml`
 
-- **On push/PR/workflow_call**: `docker-image-test` job runs `make ci` (lint + build) to verify the build works
-- **On tag push (v*)**: three jobs run in sequence:
-  1. `docker-image-test` — lint and build verification
-  2. `docker-image-builder` — builds and pushes amd64-only builder image to ghcr.io
-  3. `docker-image-runtime` — builds and pushes multi-platform (`linux/arm64,linux/amd64`) runtime image to ghcr.io
-- Uses `secrets.GITHUB_TOKEN` for ghcr.io authentication
+- **`changes`** (all events): `dorny/paths-filter` skips the build on docs-only changes (`*.md`, `LICENSE`).
+- **On push/PR/workflow_call**: `docker-image-test` runs `make ci` (hadolint + Trivy filesystem scan + builder/runtime build) — gated on `changes` (or any tag).
+- **On tag push (v*)**: three jobs run in sequence after `docker-image-test`:
+  1. `docker-image-builder` — builds + pushes the amd64 builder image to ghcr.io, then cosign-signs it (`id-token: write`).
+  2. `docker-image-runtime` — builds the runtime image (amd64) → **Trivy image scan** (CRITICAL/HIGH blocking) → **smoke test** (`qm-x86_64` prints `sqrt(2)`) → pushes multi-platform (`linux/arm64,linux/amd64`) → cosign-signs the digest.
+- **`ci-pass`** (all events): aggregator that fails if a required job failed/cancelled — the intended single required status check.
+- Uses `secrets.GITHUB_TOKEN` for ghcr.io auth; cosign uses keyless OIDC (Sigstore).
+- The builder image is **not** CVE-gated (it is a dev-toolchain image with expected `-dev`/compiler CVEs that never reach the Alpine runtime); the runtime image — the artifact users run — is the gated one.
 
 ### Cleanup workflow: `.github/workflows/cleanup-runs.yml`
 
@@ -83,12 +96,13 @@ make renovate-validate # Validate Renovate configuration
 - Version tracked in `version.txt` and git tags (current: v0.0.2)
 - GCC version is parameterized via `ARG GCC_VERSION=14` in Dockerfile.builder
 - All C binaries are statically linked (`-static`) for portability across architectures
-- Renovate manages dependency updates with branch automerge enabled
+- Renovate manages dependency updates with PR automerge (squash) enabled
+- **Version manager**: mise (`.mise.toml`) provides Node.js (used only by `make renovate-validate`); auto-installed tools (hadolint, act, trivy) live in `~/.local/bin` (no sudo), which the Makefile adds to `PATH`
+- **Boost** is consumed header-only via apt (`libboost-dev`); `float128_example.cpp` is a frozen third-party Boost.Math example, so no Boost version bump is needed unless new Boost features are required
 
 ## Upgrade Backlog
 
 - [ ] `ARG GCC_VERSION=14` in Dockerfile.builder is not tracked by Renovate — manually update when Ubuntu Noble ships GCC 15 (verified 2026-04-03: gcc-15 not yet in Noble repos)
-- Boost 1.83 (apt, header-only usage) is sufficient — all Boost usage is header-only (`float128_example.cpp` is a frozen third-party example); no upgrade needed unless new Boost features are required
 
 ## Skills
 
@@ -99,6 +113,6 @@ Use the following skills when working on related files:
 | `Makefile` | `/makefile` |
 | `renovate.json` | `/renovate` |
 | `README.md` | `/readme` |
-| `.github/workflows/*.yml` | `/ci-workflow` |
+| `.github/workflows/*.{yml,yaml}` | `/ci-workflow` |
 
 When spawning subagents, always pass conventions from the respective skill into the agent's prompt.

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -61,5 +61,18 @@ RUN x86_64-linux-gnu-g++ -Wall -std=gnu++14 -fexceptions -fext-numeric-literals 
     -c float128_example.cpp -o float128.o
 RUN x86_64-linux-gnu-g++ -static -o float128-x86_64 float128.o -lquadmath
 
+# Behavioral verification — run every compiled binary and assert its output.
+# amd64 binaries run natively; the arm64 binary runs under qemu-aarch64-static
+# (from qemu-user-static, installed above) with no binfmt registration needed
+# because every binary is statically linked. A broken or incorrect artifact
+# fails the image build here, not at first runtime use. Output is redirected to
+# files (no pipes) so the assertions are hadolint DL4006-clean.
+RUN set -eux; \
+    ./hello-x86_64                    > /tmp/hello-x86_64.out  && grep -q 'Total Number of args:'      /tmp/hello-x86_64.out;  \
+    qemu-aarch64-static ./hello-arm64 > /tmp/hello-arm64.out   && grep -q 'Total Number of args:'      /tmp/hello-arm64.out;   \
+    ./qm-x86_64                       > /tmp/qm-x86_64.out      && grep -q '1.41421356237309504880'     /tmp/qm-x86_64.out;     \
+    ./float128-x86_64                 > /tmp/float128-x86_64.out && grep -q 'boost::float128_t is available' /tmp/float128-x86_64.out; \
+    rm -f /tmp/hello-x86_64.out /tmp/hello-arm64.out /tmp/qm-x86_64.out /tmp/float128-x86_64.out
+
 # Keep the container running
 CMD ["tail", "-f", "/dev/null"]

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -1,4 +1,8 @@
-FROM ghcr.io/andriykalashnykov/quadmath-cross:v0.0.2-builder AS builder
+# Builder image is parameterized so CI pulls the exact tag being released
+# (the docker-image-runtime job passes BUILDER_IMAGE=...:${tag}-builder). The
+# default is only a fallback for a manual `docker build` without --build-arg.
+ARG BUILDER_IMAGE=ghcr.io/andriykalashnykov/quadmath-cross:v0.0.2-builder
+FROM ${BUILDER_IMAGE} AS builder
 
 FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS runtime
 

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
 .DEFAULT_GOAL := help
 
+# Tools installed by the deps-* targets land in ~/.local/bin (no sudo). Export
+# it so a recipe that just installed a tool can immediately invoke it, and so
+# `make ci-run` (act) finds the same binaries.
+export PATH := $(HOME)/.local/bin:$(PATH)
+
 APP_NAME       := quadmath-cross
 CURRENTTAG     := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 NEWTAG         ?= $(shell bash -c 'read -p "Please provide a new tag (current tag - $(CURRENTTAG)): " newtag; echo $$newtag')
 
-# === Tool Versions (pinned) ===
+# === Tool Versions (pinned; tracked by renovate.json customManagers) ===
 HADOLINT_VERSION := 2.14.0
 ACT_VERSION      := 0.2.87
-NVM_VERSION      := 0.40.4
-NODE_VERSION     := 24
+TRIVY_VERSION    := 0.70.0
+# Node.js is pinned in .mise.toml (Renovate `mise` manager); used only by
+# `make renovate-validate`.
 
 # === Docker Image Settings ===
 DOCKER_REGISTRY  ?= docker.io
@@ -68,21 +74,40 @@ lint: deps-hadolint
 	@hadolint Dockerfile.runtime
 	@hadolint Dockerfile.runtime.local
 
-#ci: @ Run full local CI pipeline (lint + build)
-ci: deps lint build
+#trivy-fs: @ Scan the repository for vulnerabilities and secrets with trivy
+trivy-fs: deps-trivy
+	@trivy fs --scanners vuln,secret --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 .
+
+#smoke: @ Run every compiled binary and assert its output (incl. arm64 under QEMU)
+smoke: build
+	@echo "Smoke-testing runtime image binaries (amd64)..."
+	@out="$$(docker run --rm $(DOCKER_IMAGE):$(CURRENTTAG)-runtime /app/hello-x86_64)"; \
+		case "$$out" in *"Total Number of args:"*) echo "  PASS hello-x86_64";; *) echo "  FAIL hello-x86_64: $$out"; exit 1;; esac
+	@out="$$(docker run --rm $(DOCKER_IMAGE):$(CURRENTTAG)-runtime /app/qm-x86_64)"; \
+		case "$$out" in *1.41421356237309504880*) echo "  PASS qm-x86_64";; *) echo "  FAIL qm-x86_64: $$out"; exit 1;; esac
+	@out="$$(docker run --rm $(DOCKER_IMAGE):$(CURRENTTAG)-runtime /app/float128-x86_64)"; \
+		case "$$out" in *"boost::float128_t is available"*) echo "  PASS float128-x86_64";; *) echo "  FAIL float128-x86_64: $$out"; exit 1;; esac
+	@echo "Smoke-testing arm64 binary via builder qemu-aarch64-static..."
+	@out="$$(docker run --rm $(DOCKER_IMAGE):$(CURRENTTAG)-builder qemu-aarch64-static /app/hello-arm64)"; \
+		case "$$out" in *"Total Number of args:"*) echo "  PASS hello-arm64 (qemu)";; *) echo "  FAIL hello-arm64: $$out"; exit 1;; esac
+	@echo "All smoke tests passed."
+
+#ci: @ Run full local CI pipeline (lint + filesystem scan + build + smoke)
+ci: deps lint trivy-fs build smoke
 	@echo "Local CI pipeline passed."
 
 #release: @ Create and push a new tag
 release:
 	@$(eval NT=$(NEWTAG))
 	@echo "$(NT)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$' || { echo "Error: Tag must match vN.N.N"; exit 1; }
+	@git diff --quiet && git diff --cached --quiet || { echo "Error: working tree is dirty; commit or stash changes before releasing."; exit 1; }
 	@echo -n "Are you sure to create and push $(NT) tag? [y/N] " && read ans && [ $${ans:-N} = y ]
 	@echo $(NT) > ./version.txt
 	@git add version.txt
 	@git commit -m "Cut $(NT) release"
 	@git tag $(NT)
+	@git push origin HEAD
 	@git push origin $(NT)
-	@git push
 	@echo "Done."
 
 #tag-delete: @ Delete a tag locally and from origin (destructive, requires confirmation)
@@ -96,15 +121,24 @@ tag-delete:
 #deps-hadolint: @ Install hadolint for Dockerfile linting
 deps-hadolint:
 	@command -v hadolint >/dev/null 2>&1 || { echo "Installing hadolint $(HADOLINT_VERSION)..."; \
+		mkdir -p $$HOME/.local/bin && \
 		curl -sSfL -o /tmp/hadolint https://github.com/hadolint/hadolint/releases/download/v$(HADOLINT_VERSION)/hadolint-Linux-x86_64 && \
-		install -m 755 /tmp/hadolint /usr/local/bin/hadolint && \
+		install -m 755 /tmp/hadolint $$HOME/.local/bin/hadolint && \
 		rm -f /tmp/hadolint; \
 	}
 
 #deps-act: @ Install act for running GitHub Actions locally
 deps-act:
 	@command -v act >/dev/null 2>&1 || { echo "Installing act $(ACT_VERSION)..."; \
-		curl -sSfL https://raw.githubusercontent.com/nektos/act/v$(ACT_VERSION)/install.sh | sudo bash -s -- -b /usr/local/bin v$(ACT_VERSION); \
+		mkdir -p $$HOME/.local/bin && \
+		curl -sSfL https://raw.githubusercontent.com/nektos/act/v$(ACT_VERSION)/install.sh | bash -s -- -b $$HOME/.local/bin v$(ACT_VERSION); \
+	}
+
+#deps-trivy: @ Install trivy for filesystem vulnerability and secret scanning
+deps-trivy:
+	@command -v trivy >/dev/null 2>&1 || { echo "Installing trivy $(TRIVY_VERSION)..."; \
+		mkdir -p $$HOME/.local/bin && \
+		curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b $$HOME/.local/bin v$(TRIVY_VERSION); \
 	}
 
 #ci-run: @ Run GitHub Actions workflow locally using act
@@ -112,21 +146,18 @@ ci-run: deps-act
 	@act push --container-architecture linux/amd64 \
 		--artifact-server-path /tmp/act-artifacts
 
-#renovate-bootstrap: @ Install nvm and npm for Renovate
+#renovate-bootstrap: @ Install mise and the Node.js toolchain (.mise.toml) for Renovate
 renovate-bootstrap:
-	@command -v node >/dev/null 2>&1 || { \
-		echo "Installing nvm $(NVM_VERSION)..."; \
-		curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v$(NVM_VERSION)/install.sh | bash; \
-		export NVM_DIR="$$HOME/.nvm"; \
-		[ -s "$$NVM_DIR/nvm.sh" ] && . "$$NVM_DIR/nvm.sh"; \
-		nvm install $(NODE_VERSION); \
+	@command -v mise >/dev/null 2>&1 || { echo "Installing mise..."; \
+		curl -fsSL https://mise.run | sh; \
 	}
+	@mise install
 
 #renovate-validate: @ Validate Renovate configuration
 renovate-validate: renovate-bootstrap
-	@npx --yes renovate --platform=local
+	@mise exec -- npx --yes renovate@latest --platform=local
 
 .PHONY: help version clean deps build image-run image-prune cross-compile setup-binfmt \
-	lint ci release tag-delete \
-	deps-hadolint deps-act ci-run \
+	lint trivy-fs smoke ci release tag-delete \
+	deps-hadolint deps-act deps-trivy ci-run \
 	renovate-bootstrap renovate-validate

--- a/README.md
+++ b/README.md
@@ -5,15 +5,30 @@
 
 # Quadmath Cross-Compilation
 
-Docker-based cross-compilation environment for building 128-bit floating-point (quadruple precision) C/C++ programs across multiple CPU architectures (amd64, arm64, arm, armel). Uses GCC 14 cross-compilation toolchains inside Docker with QEMU for multi-arch emulation, Boost multiprecision for C++ float128 support, and publishes multi-platform images to GitHub Container Registry.
+**quadmath-cross** is a Docker-based cross-compilation environment for building 128-bit
+floating-point (quadruple-precision) C/C++ programs across multiple CPU architectures
+(amd64, arm64, arm, armel).
+
+It cross-compiles **statically-linked** binaries that exercise `__float128` via
+**GCC libquadmath** (the C quad-math API: `sqrtq`, `quadmath_snprintf`) and
+**Boost.Multiprecision** `float128`, using **GCC 14** cross-toolchains with
+**QEMU user-static** for multi-arch emulation.
+
+The delivery pipeline is a **two-stage Docker build**: a fat **builder** image
+(Ubuntu Noble + full cross-toolchain, with **cppcheck** static analysis) compiles the
+binaries, and a minimal **Alpine runtime** image carries only the resulting static
+binaries. **hadolint** lints the Dockerfiles, **Trivy** scans the filesystem and the
+runtime image for CVEs/secrets, and **GitHub Actions** publishes **cosign**-signed
+multi-platform images to **GitHub Container Registry**, with **Renovate** keeping
+dependencies current.
 
 ## Quick Start
 
 ```bash
-make setup-binfmt  # setup QEMU binfmt for arm64 emulation (one-time)
-make build         # build amd64 builder image + runtime image
-make lint          # lint all Dockerfiles with hadolint
-make image-run     # run arm64 runtime image interactively
+make setup-binfmt  # set up QEMU binfmt for arm64 emulation (one-time)
+make build         # build amd64 builder image + local runtime image
+make image-run     # run the arm64 runtime image interactively
+make ci            # full local pipeline: lint + filesystem scan + build
 ```
 
 ## Prerequisites
@@ -24,7 +39,72 @@ make image-run     # run arm64 runtime image interactively
 | [Docker](https://www.docker.com/) | latest | Container builds with Buildx |
 | [Git](https://git-scm.com/) | 2.0+ | Version control and tagging |
 | [hadolint](https://github.com/hadolint/hadolint) | 2.14.0 | Dockerfile linting (auto-installed by `make lint`) |
-| [act](https://github.com/nektos/act) | 0.2.87 | Run GitHub Actions locally (auto-installed by `make ci-run`) |
+| [Trivy](https://trivy.dev/) | 0.70.0 | Filesystem CVE/secret scanning (auto-installed by `make trivy-fs`) |
+| [act](https://github.com/nektos/act) | 0.2.88 | Run GitHub Actions locally (auto-installed by `make ci-run`) |
+| [mise](https://mise.jdx.dev/) | latest | Provides Node.js (`.mise.toml`) for `make renovate-validate` (auto-installed) |
+
+Auto-installed tools land in `~/.local/bin` (no `sudo`); make sure it is on your `PATH`.
+
+## Architecture
+
+### Two-stage Docker build
+
+1. **Builder image** (`Dockerfile.builder`) — Ubuntu Noble (amd64) with the full
+   cross-compilation toolchain (GCC 14 for x86_64/aarch64/arm/armhf, libquadmath,
+   gfortran, LAPACK/BLAS/ATLAS, Boost). It runs **cppcheck** on the project's own
+   sources, then compiles every C/C++ source into a statically-linked binary.
+2. **Runtime image** (`Dockerfile.runtime` for CI, `Dockerfile.runtime.local` for
+   `make build`) — Alpine carrying **only** the compiled binaries. The builder image
+   reference is a build-arg (`BUILDER_IMAGE`), so CI pulls the exact `<tag>-builder`
+   image for the release being built — no manual version bumping.
+
+### Binary verification
+
+Compilation alone proves the binaries link; it does not prove they *run*. Two
+layers assert behavior:
+
+- **Build time** (`Dockerfile.builder`): immediately after compilation, every
+  binary is executed and its output asserted — the arm64 binary via
+  `qemu-aarch64-static` (statically linked, no binfmt needed). A broken or
+  incorrect artifact fails the image build.
+- **`make smoke`** (folded into `make ci`): runs the binaries out of the built
+  images and asserts output (√2 from `qm-x86_64`, `boost::float128_t is
+  available` from `float128-x86_64`, argv echo from the `hello-*` pair).
+
+### Sources → binaries
+
+| Source | Binary | Compiler | Notes |
+|--------|--------|----------|-------|
+| `hello.c` | `hello-x86_64`, `hello-arm64` | x86_64 / aarch64 gcc | Static cross-compilation smoke test |
+| `quadmath.cpp` | `qm-x86_64` | x86_64 g++ | `sqrt(2)` via `__float128` + libquadmath C API |
+| `float128_example.cpp` | `float128-x86_64` | x86_64 g++ | Boost.Multiprecision `float128` example (frozen third-party Boost source) |
+| `helloworld.c` | — | local cross-compilers | Used only by `make cross-compile`, not by Docker |
+
+### Supply chain
+
+Published images are digest-pinned at the base (Ubuntu Noble, Alpine), built from
+SHA-pinned GitHub Actions, **scanned** with Trivy and **smoke-tested** before push, and
+**signed** with cosign keyless (Sigstore OIDC). Verify a published image with:
+
+```bash
+cosign verify ghcr.io/andriykalashnykov/quadmath-cross:<tag>-runtime \
+  --certificate-identity-regexp 'https://github.com/AndriyKalashnykov/quadmath-cross/.+' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com
+```
+
+## Tech Stack
+
+| Component | Technology |
+|-----------|------------|
+| Cross toolchain | GCC 14 (x86_64, aarch64, arm, armhf cross-compilers) |
+| Quad-precision math | libquadmath / `__float128`, Boost.Multiprecision `float128` |
+| Multi-arch emulation | QEMU user-static + binfmt |
+| Builder base | Ubuntu 24.04 (Noble), digest-pinned |
+| Runtime base | Alpine 3.23, digest-pinned |
+| Static analysis | cppcheck (sources), hadolint (Dockerfiles), Trivy (filesystem + image) |
+| Supply chain | cosign keyless signing (Sigstore), GitHub Actions, GHCR |
+| Tooling | GNU Make, mise (Node.js for Renovate), act |
+| Dependency updates | Renovate |
 
 ## Available Make Targets
 
@@ -34,34 +114,37 @@ Run `make help` to see all available targets.
 
 | Target | Description |
 |--------|-------------|
-| `make build` | Build amd64 builder image and runtime image |
+| `make build` | Build amd64 builder image and local runtime image |
 | `make image-run` | Run arm64 runtime image interactively |
 | `make image-prune` | Docker system prune and buildx prune |
-| `make cross-compile` | Cross-compile helloworld.c for x86_64, arm, and aarch64 |
-| `make setup-binfmt` | Setup Docker binfmt support for arm64 emulation on x86_64 |
-| `make clean` | Remove build artifacts |
-| `make deps` | Check required system dependencies |
+| `make cross-compile` | Cross-compile `helloworld.c` for x86_64, arm, aarch64 (requires local cross-compilers, e.g. `arm-linux-gnueabi-gcc`) |
+| `make setup-binfmt` | Set up Docker binfmt support for arm64 emulation on x86_64 |
 
 ### Code Quality
 
 | Target | Description |
 |--------|-------------|
 | `make lint` | Lint all Dockerfiles with [hadolint](https://github.com/hadolint/hadolint) |
-
-### Dependencies
-
-| Target | Description |
-|--------|-------------|
-| `make deps-hadolint` | Install [hadolint](https://github.com/hadolint/hadolint) for Dockerfile linting |
-| `make deps-act` | Install [act](https://github.com/nektos/act) for running GitHub Actions locally |
-| `make renovate-bootstrap` | Install nvm and npm for Renovate validation |
+| `make trivy-fs` | Scan the repository for vulnerabilities and secrets with [Trivy](https://trivy.dev/) |
+| `make smoke` | Run every compiled binary and assert its output (amd64 natively; arm64 under QEMU) |
 
 ### CI
 
 | Target | Description |
 |--------|-------------|
-| `make ci` | Full local CI pipeline (lint + build) |
-| `make ci-run` | Run GitHub Actions workflow locally using [act](https://github.com/nektos/act) |
+| `make ci` | Full local CI pipeline (lint + filesystem scan + build + smoke) |
+| `make ci-run` | Run the GitHub Actions workflow locally using [act](https://github.com/nektos/act) |
+
+### Dependencies & Setup
+
+| Target | Description |
+|--------|-------------|
+| `make deps` | Check required system dependencies (Docker, Git) |
+| `make clean` | Remove build artifacts |
+| `make deps-hadolint` | Install [hadolint](https://github.com/hadolint/hadolint) |
+| `make deps-act` | Install [act](https://github.com/nektos/act) |
+| `make deps-trivy` | Install [Trivy](https://trivy.dev/) |
+| `make renovate-bootstrap` | Install [mise](https://mise.jdx.dev/) and the Node.js toolchain (`.mise.toml`) |
 
 ### Utilities
 
@@ -78,13 +161,15 @@ GitHub Actions runs on every push to `main`, tags `v*`, pull requests, and `work
 
 | Job | Triggers | Description |
 |-----|----------|-------------|
-| **docker-image-test** | push, PR, workflow_call | Lints Dockerfiles and builds builder + runtime images to verify the build works |
-| **docker-image-builder** | tag push (v*) | Builds and pushes amd64 builder image to ghcr.io |
-| **docker-image-runtime** | tag push (v*) | Builds and pushes multi-platform (arm64 + amd64) runtime image to ghcr.io |
+| **changes** | all | Path filter — skips the build for docs-only changes (`*.md`, `LICENSE`) |
+| **docker-image-test** | push, PR, workflow_call | Runs `make ci` (hadolint + Trivy filesystem scan + builder/runtime build) |
+| **docker-image-builder** | tag push (`v*`) | Builds and pushes the amd64 builder image to ghcr.io, then cosign-signs it |
+| **docker-image-runtime** | tag push (`v*`) | Builds the runtime image, **Trivy-scans + smoke-tests** it, pushes multi-platform (arm64 + amd64) to ghcr.io, then cosign-signs it |
+| **ci-pass** | all | Aggregator gate — succeeds only if the required jobs passed (suitable as a single required status check) |
 
 A [cleanup workflow](https://github.com/AndriyKalashnykov/quadmath-cross/actions/workflows/cleanup-runs.yml) runs weekly to prune workflow runs older than 7 days.
 
-[Renovate](https://docs.renovatebot.com/) keeps dependencies up to date with platform automerge enabled.
+[Renovate](https://docs.renovatebot.com/) keeps dependencies up to date with PR automerge (squash) enabled.
 
 ## License
 

--- a/renovate.json
+++ b/renovate.json
@@ -10,11 +10,17 @@
   "labels": [
     "dependencies"
   ],
+  "enabledManagers": [
+    "github-actions",
+    "dockerfile",
+    "mise",
+    "custom.regex"
+  ],
   "prConcurrentLimit": 50,
   "prHourlyLimit": 0,
   "platformAutomerge": true,
   "automerge": true,
-  "automergeType": "branch",
+  "automergeType": "pr",
   "automergeStrategy": "squash",
   "ignoreTests": false,
   "lockFileMaintenance": {
@@ -53,24 +59,14 @@
     },
     {
       "customType": "regex",
-      "description": "Track nvm version in Makefile",
+      "description": "Track trivy version in Makefile",
       "managerFilePatterns": ["/^Makefile$/"],
       "matchStrings": [
-        "NVM_VERSION\\s*:=\\s*(?<currentValue>.*?)\\n"
+        "TRIVY_VERSION\\s*:=\\s*(?<currentValue>.*?)\\n"
       ],
-      "depNameTemplate": "nvm-sh/nvm",
+      "depNameTemplate": "aquasecurity/trivy",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
-    },
-    {
-      "customType": "regex",
-      "description": "Track Node.js major version in Makefile",
-      "managerFilePatterns": ["/^Makefile$/"],
-      "matchStrings": [
-        "NODE_VERSION\\s*:=\\s*(?<currentValue>\\d+)\\n"
-      ],
-      "depNameTemplate": "node",
-      "datasourceTemplate": "node-version"
     },
     {
       "customType": "regex",


### PR DESCRIPTION
Applies the `/project-review` findings (foundation hardening) plus the `/test-coverage-analysis` binary-verification layer. All changes validated end-to-end locally (`make ci` green: lint + trivy-fs + build + smoke).

## Foundation (project-review)

- **Makefile**: migrate `nvm` → **mise** (`.mise.toml` `node=24`); install hadolint/act/trivy to `~/.local/bin` (no `sudo`) with exported `PATH`; add `TRIVY_VERSION` + `deps-trivy` + `trivy-fs` gate; `renovate-validate` via `mise exec npx renovate@latest`; `release` dirty-tree guard + `git push origin HEAD`.
- **renovate.json**: scoped `enabledManagers` (+`mise`); drop nvm/node managers (node now tracked via `.mise.toml`); add `trivy` customManager; `automergeType` `branch` → **`pr`** (repo has `allow_auto_merge`).
- **ci.yml**: `name: CI`; canonical step names; `changes` path-filter + `ci-pass` aggregator; parameterized runtime `BUILDER_IMAGE` build-arg; runtime image **Trivy-scanned + smoke-tested before push**; **cosign keyless signing** of builder and runtime (`id-token: write`).
- **Dockerfile.runtime**: `ARG BUILDER_IMAGE` (CI passes `${tag}-builder`) — eliminates the hardcoded-version coupling.

## Binary verification (test-coverage-analysis)

- **Dockerfile.builder**: build-time `RUN` executes + asserts every compiled binary; the **arm64 binary runs under `qemu-aarch64-static`** (static, no binfmt). A broken artifact now fails the image build.
- **Makefile**: `make smoke` runs all binaries from the built images (arm64 via the builder's qemu), folded into `make ci`.

## Docs

`README.md` / `CLAUDE.md` re-derived from post-change state: Architecture, Tech Stack, binary-verification layer, GitHub About alignment, mise/trivy/cosign.

## Verification

- `make ci` green end-to-end; build-time arm64 QEMU assertion + all 4 `make smoke` checks pass.
- actionlint, hadolint, `renovate-config-validator` all clean.

## Notes for the maintainer

- First `v*` tag after merge will push **cosign signatures to the public Sigstore/Rekor transparency log** and gate the runtime image on Trivy CRITICAL/HIGH.
- The **builder image is intentionally not CVE-gated** (dev-toolchain image with expected `-dev`/compiler CVEs that never reach the Alpine runtime); the runtime image is the gated artifact.
- Consider making `ci-pass` a required status check on `main` (it's the intended single gate).