### PR TITLE
chore: Wave 1 dependency bumps (act, base images, action SHAs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,10 +57,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Build and test Docker images
         run: make ci
@@ -87,10 +87,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Convert owner to lower case
         run: |
@@ -99,7 +99,7 @@ jobs:
           OWNER: '${{ github.repository_owner }}'
 
       - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -107,7 +107,7 @@ jobs:
 
       - name: Docker metadata
         id: meta_builder
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ghcr.io/${{ env.OWNER_LC }}/quadmath-cross
           flavor: |
@@ -128,7 +128,7 @@ jobs:
 
       - name: Build and push docker_builder
         id: docker_builder
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ./Dockerfile.builder
@@ -176,10 +176,10 @@ jobs:
           fetch-depth: 0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4
 
       - name: Convert owner to lower case
         run: |
@@ -188,7 +188,7 @@ jobs:
           OWNER: '${{ github.repository_owner }}'
 
       - name: Log in to GHCR
-        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -196,7 +196,7 @@ jobs:
 
       - name: Docker metadata
         id: meta_runtime
-        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf # v6
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6
         with:
           images: ghcr.io/${{ env.OWNER_LC }}/quadmath-cross
           flavor: |
@@ -219,7 +219,7 @@ jobs:
       # tested before any multi-arch push to the registry.
       - name: Build runtime image (amd64, for scan and smoke test)
         id: build_local
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ./Dockerfile.runtime
@@ -251,7 +251,7 @@ jobs:
 
       - name: Build and push runtime
         id: docker_runtime
-        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7
         with:
           context: .
           file: ./Dockerfile.runtime

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,7 +102,7 @@ Because the builder reference is a build-arg derived from the release tag, there
 
 ## Upgrade Backlog
 
-- [ ] `ARG GCC_VERSION=14` in Dockerfile.builder is not tracked by Renovate — manually update when Ubuntu Noble ships GCC 15 (verified 2026-04-03: gcc-15 not yet in Noble repos)
+- [ ] `ARG GCC_VERSION=14` in Dockerfile.builder is not tracked by Renovate — manually update when Ubuntu Noble ships GCC 15 (re-verified 2026-05-30: gcc-15 still not in Noble repos; gcc-14 `14.2.0` is the candidate, no `gcc-15-aarch64-linux-gnu`)
 
 ## Skills
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 #FROM amd64/debian:bookworm AS builder
-FROM amd64/ubuntu:noble-20260217@sha256:84ebf67ad1e2908cb4f21aa99c1611aafd1690ba118c7fbaf201e5cbef3c7850 AS builder
+FROM amd64/ubuntu:noble-20260410@sha256:b62cfdac2469e1f1219fe4a69475248159349ade845855228599fe9b0c16ae8e AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GCC_VERSION=14

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -4,7 +4,7 @@
 ARG BUILDER_IMAGE=ghcr.io/andriykalashnykov/quadmath-cross:v0.0.2-builder
 FROM ${BUILDER_IMAGE} AS builder
 
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS runtime
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS runtime
 
 WORKDIR /app
 

--- a/Dockerfile.runtime.local
+++ b/Dockerfile.runtime.local
@@ -1,7 +1,7 @@
 ARG BUILDER_IMAGE=docker.io/andriykalashnykov/quadmath-cross:v0.0.2-builder
 FROM ${BUILDER_IMAGE} AS builder
 
-FROM alpine:3.23.3@sha256:25109184c71bdad752c8312a8623239686a9a2071e8825f20acb8f2198c3f659 AS runtime
+FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS runtime
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ NEWTAG         ?= $(shell bash -c 'read -p "Please provide a new tag (current ta
 
 # === Tool Versions (pinned; tracked by renovate.json customManagers) ===
 HADOLINT_VERSION := 2.14.0
-ACT_VERSION      := 0.2.87
+ACT_VERSION      := 0.2.88
 TRIVY_VERSION    := 0.70.0
 # Node.js is pinned in .mise.toml (Renovate `mise` manager); used only by
 # `make renovate-validate`.


### PR DESCRIPTION
Pre-empts Renovate with the drop-in bumps surfaced by `/upgrade-analysis`. All values fetched from authoritative sources (no guesses); validated end-to-end via `make ci` on the new bases.

| Item | From | To | Source of truth |
|------|------|-----|-----------------|
| act (Makefile) | 0.2.87 | 0.2.88 | `gh api nektos/act releases/latest` |
| builder base | `ubuntu:noble-20260217` | `noble-20260410` | `buildx imagetools` index digest |
| runtime base | `alpine:3.23.3` | `3.23.4` | `buildx imagetools` index digest |
| setup-qemu-action | `ce360397`@v4 | `06116385`@v4 | `git ls-remote refs/tags/v4^{}` |
| setup-buildx-action | `4d04d5d9`@v4 | `d7f5e7f5`@v4 | `git ls-remote refs/tags/v4^{}` |
| login-action | `4907a6dd`@v4 | `650006c6`@v4 | `git ls-remote refs/tags/v4^{}` |
| metadata-action | `030e8812`@v6 | `80c7e94d`@v6 | `git ls-remote refs/tags/v6^{}` |
| build-push-action | `d08e5c35`@v7 | `f9f3042f`@v7 | `git ls-remote refs/tags/v7^{}` |

All are Renovate-managed (this PR just lands them ahead of the next Renovate cycle).

## Verification
- `make ci` green end-to-end on the new bases (full cross-toolchain rebuild — cache invalidated by the new Ubuntu digest): build-time arm64 QEMU assertion + `PASS hello-x86_64 / qm-x86_64 / float128-x86_64 / hello-arm64 (qemu)`.
- actionlint clean; no stale pins remain.

## Not in scope
- `GCC_VERSION=14` stays (gcc-15 re-verified absent in Noble 2026-05-30; CLAUDE.md backlog date updated).