### PR TITLE
ci: make paths-filter actually skip docs-only builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,11 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
+          # 'every': a file counts as `code` only if it matches '**' AND none of
+          # the '!' exclusions. The default ('some') matches a file if it matches
+          # ANY pattern, so the '**' catch-all always wins and the exclusions are
+          # ignored — making docs-only changes still trigger the full build.
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'


### PR DESCRIPTION
## Summary
Fixes a bug in the `changes` path-filter (added in PR #81): docs-only changes still trigger the full `docker-image-test` build.

- **Root cause:** dorny/paths-filter's default `predicate-quantifier: some` matches a file if it matches *any* pattern. The leading `'**'` catch-all always matches, so the `'!**/*.md'` / `'!LICENSE'` exclusions are silently ignored.
- **Evidence:** PR #83 (README-only) ran `docker-image-test` for 1m46s instead of skipping; the `changes` log showed `Filter code = true / README.md [modified]`.
- **Fix:** `predicate-quantifier: 'every'` — a file counts as `code` only if it matches `'**'` AND none of the `'!'` exclusions.

## Test plan
- [x] actionlint clean; YAML valid
- [x] This PR edits `ci.yml` (a code path) → `docker-image-test` correctly **runs** here, verifying the build still works under `every`
- [ ] **Skip behavior** confirmed on the next docs-only change (can't be tested in this PR, which is a workflow edit)