### PR TITLE
chore: portfolio-skill sweep — mise migration, dep bumps, CI/renovate hardening, non-root runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,10 @@ jobs:
       - name: Set up tools (mise)
         uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
         with:
+          # Pin mise itself for reproducible CI. As of 2026-06-14, mise.jdx.dev/VERSION
+          # advanced to 2026.6.7 before that release's linux-x64 asset was published, so
+          # the action's default (fetch latest) 404s. Bump when a newer release is healthy.
+          version: "2026.6.6"
           install: true
           cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,12 +27,17 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Filter changed paths
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
+          # `base` is required so `make ci-run` (act push) works: act's synthetic
+          # event payload omits repository.default_branch, which paths-filter
+          # falls back to. On pull_request events the action uses the PR base and
+          # ignores this input, so gate it to push events only.
+          base: ${{ github.event_name == 'push' && 'main' || '' }}
           # 'every': a file counts as `code` only if it matches '**' AND none of
           # the '!' exclusions. The default ('some') matches a file if it matches
           # ANY pattern, so the '**' catch-all always wins and the exclusions are
@@ -41,7 +46,9 @@ jobs:
           filters: |
             code:
               - '**'
-              - '!**/*.md'
+              # Exclude every .md EXCEPT CLAUDE.md — CLAUDE.md is project config,
+              # not documentation, so a change to it must trigger the build.
+              - '!**/!(CLAUDE).md'
               - '!LICENSE'
               - '!.gitignore'
               - '!.dockerignore'
@@ -57,9 +64,15 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+
+      - name: Set up tools (mise)
+        uses: jdx/mise-action@dba19683ed58901619b14f395a24841710cb4925 # v4
+        with:
+          install: true
+          cache: true
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4
@@ -87,7 +100,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -176,7 +189,7 @@ jobs:
     steps:
 
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
@@ -243,6 +256,7 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ghcr.io/${{ env.OWNER_LC }}/quadmath-cross:runtime-scan
+          scanners: vuln,secret
           severity: CRITICAL,HIGH
           ignore-unfixed: true
           exit-code: '1'
@@ -288,7 +302,10 @@ jobs:
     if: always()
     runs-on: ubuntu-24.04
     name: ci-pass
-    needs: [ changes, docker-image-test ]
+    # List ALL upstream jobs (including the tag-only publish jobs) so a failed
+    # release is visible on the commit status. Skipped jobs (builder/runtime on
+    # non-tag pushes) count as success, not failure, so this stays green on PRs.
+    needs: [ changes, docker-image-test, docker-image-builder, docker-image-runtime ]
     timeout-minutes: 5
     steps:
       - name: Verify required jobs succeeded

--- a/.github/workflows/cleanup-runs.yml
+++ b/.github/workflows/cleanup-runs.yml
@@ -13,18 +13,59 @@ permissions:
   contents: read
 
 jobs:
-  cleanup:
+  cleanup-runs:
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
       actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      RETAIN_DAYS: 7
+      KEEP_MINIMUM: 5
     steps:
       - name: Delete old workflow runs
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
         run: |
-          cutoff=$(date -u -d '7 days ago' +%Y-%m-%dT%H:%M:%SZ)
-          gh run list --limit 200 --json databaseId,createdAt \
-            --jq ".[5:] | [.[] | select(.createdAt < \"${cutoff}\")] | .[].databaseId" \
-            | xargs -rI {} gh run delete {}
+          CUTOFF=$(date -u -d "${RETAIN_DAYS} days ago" +%Y-%m-%dT%H:%M:%SZ)
+          # Retain the newest KEEP_MINIMUM runs PER WORKFLOW (group_by
+          # .workflowName), THEN delete any remaining run older than CUTOFF.
+          # A single GLOBAL minimum would deregister low-frequency workflows:
+          # gh run delete on the last run of a workflow flips it to
+          # state: deleted, removing it from required-status-check resolution.
+          gh run list --repo "${GH_REPO}" \
+            --json databaseId,createdAt,workflowName --limit 300 \
+          | jq -r --arg cutoff "$CUTOFF" --argjson keep "$KEEP_MINIMUM" '
+              group_by(.workflowName)
+              | map(sort_by(.createdAt) | reverse | .[$keep:])
+              | add // []
+              | .[] | select(.createdAt < $cutoff) | .databaseId
+            ' \
+          | xargs -r -I {} gh run delete {} --repo "${GH_REPO}"
+
+  cleanup-caches:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      actions: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+    steps:
+      - name: Delete caches from merged/deleted branches
+        run: |
+          echo "=== Cleaning caches from non-existent branches ==="
+          gh cache list --repo "${GH_REPO}" --json id,ref,key --limit 200 \
+          | jq -r '.[] | "\(.id)\t\(.ref)\t\(.key)"' \
+          | while IFS=$'\t' read -r id ref key; do
+              branch="${ref#refs/heads/}"
+              # Keep caches for the default branch and tags.
+              if [ "$branch" = "main" ] || [[ "$ref" == refs/tags/* ]]; then
+                continue
+              fi
+              # Delete the cache if its source branch no longer exists.
+              if ! gh api "repos/${GH_REPO}/branches/${branch}" --silent 2>/dev/null; then
+                echo "Deleting cache ${key} (branch ${branch} no longer exists)"
+                gh cache delete "$id" --repo "${GH_REPO}" 2>/dev/null || true
+              fi
+            done

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,12 @@
 # mise — cross-language tool versions (https://mise.jdx.dev).
-# Node.js is required only by `make renovate-validate` (runs `npx renovate`).
-# Tracked by Renovate's `mise` manager.
+# Single source of truth for every pinned CLI tool, tracked natively by
+# Renovate's `mise` manager (no inline `# renovate:` comments needed).
+#   - node:     used by `make renovate-validate` (runs `npx renovate`).
+#   - hadolint: Dockerfile linting (`make lint`).
+#   - act:      run GitHub Actions locally (`make ci-run`).
+#   - trivy:    filesystem vulnerability/secret scanning (`make trivy-fs`).
 [tools]
 node = "24"
+"aqua:hadolint/hadolint" = "2.14.0"
+"aqua:nektos/act" = "0.2.89"
+"aqua:aquasecurity/trivy" = "0.71.0"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ All builds are Docker-based. There is no local compilation pipeline outside of D
 ```bash
 make help              # List all targets
 make deps              # Check required system dependencies (docker, git)
+make deps-tools        # Install pinned CLI tools (hadolint, act, trivy, node) via mise
 make build             # Build amd64 builder image, then local runtime image (the main build)
 make image-run         # Run arm64 runtime image interactively
 make image-prune       # Docker system prune + buildx prune
@@ -43,7 +44,7 @@ make renovate-validate # Validate Renovate configuration
    - Compiles all C/C++ sources into statically-linked binaries at build time
    - **Behavioral verification**: after compilation, every binary is executed and its output asserted (arm64 via `qemu-aarch64-static`, no binfmt needed since binaries are static). A broken artifact fails the image build. `make smoke` repeats these assertions against the built images and is folded into `make ci`.
 
-2. **Runtime image** (`Dockerfile.runtime` / `Dockerfile.runtime.local`) - Alpine with only the compiled binaries. Both take an `ARG BUILDER_IMAGE` so the builder reference is supplied at build time:
+2. **Runtime image** (`Dockerfile.runtime` / `Dockerfile.runtime.local`) - Alpine with only the compiled binaries, running as a non-root user (UID 10001). Both take an `ARG BUILDER_IMAGE` so the builder reference is supplied at build time:
    - `Dockerfile.runtime` (CI): the `docker-image-runtime` job passes `BUILDER_IMAGE=ghcr.io/<owner>/quadmath-cross:${tag}-builder`, so the runtime always pulls the exact builder for the release being built.
    - `Dockerfile.runtime.local` (`make build`): `make build` passes the just-built local `docker.io/$(DOCKER_ORG)/quadmath-cross:<tag>-builder`.
    - The `ARG` default in each file is only a fallback for a bare `docker build` without `--build-arg`.
@@ -77,7 +78,7 @@ Because the builder reference is a build-arg derived from the release tag, there
 
 ### Main workflow: `.github/workflows/ci.yml`
 
-- **`changes`** (all events): `dorny/paths-filter` skips the build on docs-only changes (`*.md`, `LICENSE`).
+- **`changes`** (all events): `dorny/paths-filter` skips the build on docs-only changes (`*.md` except `CLAUDE.md`, `LICENSE`, `.gitignore`, `.dockerignore`). `CLAUDE.md` is re-included as code (it's project config, not docs).
 - **On push/PR/workflow_call**: `docker-image-test` runs `make ci` (hadolint + Trivy filesystem scan + builder/runtime build) — gated on `changes` (or any tag).
 - **On tag push (v*)**: three jobs run in sequence after `docker-image-test`:
   1. `docker-image-builder` — builds + pushes the amd64 builder image to ghcr.io, then cosign-signs it (`id-token: write`).
@@ -97,12 +98,12 @@ Because the builder reference is a build-arg derived from the release tag, there
 - GCC version is parameterized via `ARG GCC_VERSION=14` in Dockerfile.builder
 - All C binaries are statically linked (`-static`) for portability across architectures
 - Renovate manages dependency updates with PR automerge (squash) enabled
-- **Version manager**: mise (`.mise.toml`) provides Node.js (used only by `make renovate-validate`); auto-installed tools (hadolint, act, trivy) live in `~/.local/bin` (no sudo), which the Makefile adds to `PATH`
+- **Version manager**: mise (`.mise.toml`) is the single source of truth for every pinned CLI tool — Node.js (for `make renovate-validate`), hadolint (`make lint`), trivy (`make trivy-fs`), and act (`make ci-run`), all via aqua backends and tracked by Renovate's native `mise` manager. `make deps-tools` runs `mise install`; mise's shims dir is on the Makefile's `PATH`. CI installs them via `jdx/mise-action`. The only Makefile-pinned image is the binfmt installer (consumed via `docker run`, tracked by a renovate.json customManager)
 - **Boost** is consumed header-only via apt (`libboost-dev`); `float128_example.cpp` is a frozen third-party Boost.Math example, so no Boost version bump is needed unless new Boost features are required
 
 ## Upgrade Backlog
 
-- [ ] `ARG GCC_VERSION=14` in Dockerfile.builder is not tracked by Renovate — manually update when Ubuntu Noble ships GCC 15 (re-verified 2026-05-30: gcc-15 still not in Noble repos; gcc-14 `14.2.0` is the candidate, no `gcc-15-aarch64-linux-gnu`)
+- [ ] `ARG GCC_VERSION=14` in Dockerfile.builder is not tracked by Renovate — manually update when Ubuntu Noble ships GCC 15 (re-verified 2026-06-14: gcc-15 still not in Noble repos; gcc-14 `14.2.0` is the candidate, no `gcc-15-aarch64-linux-gnu`)
 
 ## Skills
 

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 #FROM amd64/debian:bookworm AS builder
-FROM amd64/ubuntu:noble-20260410@sha256:b62cfdac2469e1f1219fe4a69475248159349ade845855228599fe9b0c16ae8e AS builder
+FROM amd64/ubuntu:noble-20260509.1@sha256:ff32d54215b8fb6e315be754f45dec57341437ec6c4e4a95026ee6a234f5baf9 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG GCC_VERSION=14

--- a/Dockerfile.runtime
+++ b/Dockerfile.runtime
@@ -6,12 +6,18 @@ FROM ${BUILDER_IMAGE} AS builder
 
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS runtime
 
+# Run as a non-root user. The binaries are statically linked and copied
+# world-executable (gcc default 0755), so a non-root UID can run them.
+RUN addgroup -S app && adduser -S -H -D -s /sbin/nologin -u 10001 -G app app
+
 WORKDIR /app
 
 COPY --from=builder /app/hello-x86_64 .
 COPY --from=builder /app/hello-arm64 .
 COPY --from=builder /app/qm-x86_64 .
 COPY --from=builder /app/float128-x86_64 .
+
+USER 10001
 
 # Keep the container running
 CMD ["tail", "-f", "/dev/null"]

--- a/Dockerfile.runtime.local
+++ b/Dockerfile.runtime.local
@@ -3,12 +3,18 @@ FROM ${BUILDER_IMAGE} AS builder
 
 FROM alpine:3.23.4@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11 AS runtime
 
+# Run as a non-root user. The binaries are statically linked and copied
+# world-executable (gcc default 0755), so a non-root UID can run them.
+RUN addgroup -S app && adduser -S -H -D -s /sbin/nologin -u 10001 -G app app
+
 WORKDIR /app
 
 COPY --from=builder /app/hello-x86_64 .
 COPY --from=builder /app/hello-arm64 .
 COPY --from=builder /app/qm-x86_64 .
 COPY --from=builder /app/float128-x86_64 .
+
+USER 10001
 
 # Keep the container running
 CMD ["tail", "-f", "/dev/null"]

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,21 @@
 .DEFAULT_GOAL := help
 
-# Tools installed by the deps-* targets land in ~/.local/bin (no sudo). Export
-# it so a recipe that just installed a tool can immediately invoke it, and so
-# `make ci-run` (act) finds the same binaries.
-export PATH := $(HOME)/.local/bin:$(PATH)
+# CLI tools (hadolint, act, trivy, node) are installed by mise into its shims
+# dir; mise's auto-activation does not run inside Make's $(SHELL) -c sub-shells,
+# so put the shims dir on PATH explicitly. ~/.local/bin stays for mise itself
+# (bootstrapped via https://mise.run) and any hand-installed binary.
+export PATH := $(HOME)/.local/share/mise/shims:$(HOME)/.local/bin:$(PATH)
 
 APP_NAME       := quadmath-cross
 CURRENTTAG     := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "dev")
 NEWTAG         ?= $(shell bash -c 'read -p "Please provide a new tag (current tag - $(CURRENTTAG)): " newtag; echo $$newtag')
 
-# === Tool Versions (pinned; tracked by renovate.json customManagers) ===
-HADOLINT_VERSION := 2.14.0
-ACT_VERSION      := 0.2.88
-TRIVY_VERSION    := 0.70.0
-# Node.js is pinned in .mise.toml (Renovate `mise` manager); used only by
-# `make renovate-validate`.
+# === Tool Versions ===
+# hadolint, act, trivy, and node are pinned in .mise.toml (single source of
+# truth, tracked by Renovate's native `mise` manager) and installed by
+# `make deps-tools`. The only image pinned here is the binfmt installer used by
+# `setup-binfmt` (consumed via `docker run`, so it stays a Makefile reference
+# tracked by a renovate.json customManager).
 
 # === Docker Image Settings ===
 DOCKER_REGISTRY  ?= docker.io
@@ -69,13 +70,13 @@ setup-binfmt: deps
 	@echo "binfmt setup complete. Test with: docker run -it --rm --platform linux/arm64 arm64v8/ubuntu sh"
 
 #lint: @ Lint all Dockerfiles with hadolint
-lint: deps-hadolint
+lint: deps-tools
 	@hadolint Dockerfile.builder
 	@hadolint Dockerfile.runtime
 	@hadolint Dockerfile.runtime.local
 
 #trivy-fs: @ Scan the repository for vulnerabilities and secrets with trivy
-trivy-fs: deps-trivy
+trivy-fs: deps-tools
 	@trivy fs --scanners vuln,secret --severity CRITICAL,HIGH --ignore-unfixed --exit-code 1 .
 
 #smoke: @ Run every compiled binary and assert its output (incl. arm64 under QEMU)
@@ -118,46 +119,30 @@ tag-delete:
 		git push --delete origin $$tag && \
 		git tag --delete $$tag'
 
-#deps-hadolint: @ Install hadolint for Dockerfile linting
-deps-hadolint:
-	@command -v hadolint >/dev/null 2>&1 || { echo "Installing hadolint $(HADOLINT_VERSION)..."; \
-		mkdir -p $$HOME/.local/bin && \
-		curl -sSfL -o /tmp/hadolint https://github.com/hadolint/hadolint/releases/download/v$(HADOLINT_VERSION)/hadolint-Linux-x86_64 && \
-		install -m 755 /tmp/hadolint $$HOME/.local/bin/hadolint && \
-		rm -f /tmp/hadolint; \
-	}
-
-#deps-act: @ Install act for running GitHub Actions locally
-deps-act:
-	@command -v act >/dev/null 2>&1 || { echo "Installing act $(ACT_VERSION)..."; \
-		mkdir -p $$HOME/.local/bin && \
-		curl -sSfL https://raw.githubusercontent.com/nektos/act/v$(ACT_VERSION)/install.sh | bash -s -- -b $$HOME/.local/bin v$(ACT_VERSION); \
-	}
-
-#deps-trivy: @ Install trivy for filesystem vulnerability and secret scanning
-deps-trivy:
-	@command -v trivy >/dev/null 2>&1 || { echo "Installing trivy $(TRIVY_VERSION)..."; \
-		mkdir -p $$HOME/.local/bin && \
-		curl -sSfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b $$HOME/.local/bin v$(TRIVY_VERSION); \
-	}
+#deps-tools: @ Install pinned CLI tools (hadolint, act, trivy, node) via mise
+deps-tools:
+	@if ! command -v mise >/dev/null 2>&1; then \
+		if [ -z "$$CI" ]; then \
+			echo "Installing mise (no root; installs to ~/.local/bin)..."; \
+			curl -fsSL https://mise.run | sh; \
+		else \
+			echo "Error: mise required in CI (use jdx/mise-action)."; exit 1; \
+		fi; \
+	fi
+	@mise install --yes
 
 #ci-run: @ Run GitHub Actions workflow locally using act
-ci-run: deps-act
-	@act push --container-architecture linux/amd64 \
-		--artifact-server-path /tmp/act-artifacts
-
-#renovate-bootstrap: @ Install mise and the Node.js toolchain (.mise.toml) for Renovate
-renovate-bootstrap:
-	@command -v mise >/dev/null 2>&1 || { echo "Installing mise..."; \
-		curl -fsSL https://mise.run | sh; \
-	}
-	@mise install
+ci-run: deps-tools
+	@docker container prune -f 2>/dev/null || true
+	@ACT_PORT=$$(shuf -i 40000-59999 -n 1); \
+	act push --container-architecture linux/amd64 \
+		--artifact-server-port "$$ACT_PORT" \
+		--artifact-server-path "$$(mktemp -d -t act-artifacts.XXXXXX)"
 
 #renovate-validate: @ Validate Renovate configuration
-renovate-validate: renovate-bootstrap
+renovate-validate: deps-tools
 	@mise exec -- npx --yes renovate@latest --platform=local
 
-.PHONY: help version clean deps build image-run image-prune cross-compile setup-binfmt \
+.PHONY: help version clean deps deps-tools build image-run image-prune cross-compile setup-binfmt \
 	lint trivy-fs smoke ci release tag-delete \
-	deps-hadolint deps-act deps-trivy ci-run \
-	renovate-bootstrap renovate-validate
+	ci-run renovate-validate

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ publishing to **GitHub Container Registry**.
 | Runtime base | Alpine 3.23, digest-pinned |
 | Static analysis | cppcheck (sources), hadolint (Dockerfiles), Trivy (filesystem + image) |
 | Supply chain | cosign keyless signing (Sigstore), GitHub Actions, GHCR |
-| Tooling | GNU Make, mise (Node.js for Renovate), act |
+| Tooling | GNU Make, mise (pins hadolint, act, trivy, Node.js) |
 | Dependency updates | Renovate |
 
 ## Quick Start
@@ -43,12 +43,12 @@ make ci            # full local pipeline: lint + scan + build + binary smoke tes
 | [GNU Make](https://www.gnu.org/software/make/) | 3.81+ | Build orchestration |
 | [Docker](https://www.docker.com/) | latest | Container builds with Buildx |
 | [Git](https://git-scm.com/) | 2.0+ | Version control and tagging |
-| [hadolint](https://github.com/hadolint/hadolint) | 2.14.0 | Dockerfile linting (auto-installed by `make lint`) |
-| [Trivy](https://trivy.dev/) | 0.70.0 | Filesystem CVE/secret scanning (auto-installed by `make trivy-fs`) |
-| [act](https://github.com/nektos/act) | 0.2.88 | Run GitHub Actions locally (auto-installed by `make ci-run`) |
-| [mise](https://mise.jdx.dev/) | latest | Provides Node.js (`.mise.toml`) for `make renovate-validate` (auto-installed) |
+| [mise](https://mise.jdx.dev/) | latest | Manages all CLI tool versions from `.mise.toml` (auto-installed by `make deps-tools`) |
+| [hadolint](https://github.com/hadolint/hadolint) | 2.14.0 | Dockerfile linting (via mise; used by `make lint`) |
+| [Trivy](https://trivy.dev/) | 0.71.0 | Filesystem CVE/secret scanning (via mise; used by `make trivy-fs`) |
+| [act](https://github.com/nektos/act) | 0.2.89 | Run GitHub Actions locally (via mise; used by `make ci-run`) |
 
-Auto-installed tools land in `~/.local/bin` (no `sudo`); make sure it is on your `PATH`.
+Tool versions are pinned in `.mise.toml` (single source of truth, Renovate-tracked) and installed by `make deps-tools` via mise — no `sudo` required. `make lint`, `make trivy-fs`, and `make ci-run` auto-run `deps-tools` on first use.
 
 ## Architecture
 
@@ -59,9 +59,10 @@ Auto-installed tools land in `~/.local/bin` (no `sudo`); make sure it is on your
    gfortran, LAPACK/BLAS/ATLAS, Boost). It runs **cppcheck** on the project's own
    sources, then compiles every C/C++ source into a statically-linked binary.
 2. **Runtime image** (`Dockerfile.runtime` for CI, `Dockerfile.runtime.local` for
-   `make build`) — Alpine carrying **only** the compiled binaries. The builder image
-   reference is a build-arg (`BUILDER_IMAGE`), so CI pulls the exact `<tag>-builder`
-   image for the release being built — no manual version bumping.
+   `make build`) — Alpine carrying **only** the compiled binaries, running as a
+   non-root user (UID 10001). The builder image reference is a build-arg
+   (`BUILDER_IMAGE`), so CI pulls the exact `<tag>-builder` image for the release
+   being built — no manual version bumping.
 
 ### Binary verification
 
@@ -132,10 +133,7 @@ Run `make help` to see all available targets.
 |--------|-------------|
 | `make deps` | Check required system dependencies (Docker, Git) |
 | `make clean` | Remove build artifacts |
-| `make deps-hadolint` | Install [hadolint](https://github.com/hadolint/hadolint) |
-| `make deps-act` | Install [act](https://github.com/nektos/act) |
-| `make deps-trivy` | Install [Trivy](https://trivy.dev/) |
-| `make renovate-bootstrap` | Install [mise](https://mise.jdx.dev/) and the Node.js toolchain (`.mise.toml`) |
+| `make deps-tools` | Install pinned CLI tools (hadolint, act, trivy, Node.js) via [mise](https://mise.jdx.dev/) from `.mise.toml` |
 
 ### Utilities
 

--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,7 @@
   ],
   "prConcurrentLimit": 50,
   "prHourlyLimit": 0,
-  "platformAutomerge": true,
+  "platformAutomerge": false,
   "automerge": true,
   "automergeType": "pr",
   "automergeStrategy": "squash",
@@ -37,46 +37,14 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track hadolint version in Makefile",
-      "managerFilePatterns": ["/^Makefile$/"],
-      "matchStrings": [
-        "HADOLINT_VERSION\\s*:=\\s*(?<currentValue>.*?)\\n"
-      ],
-      "depNameTemplate": "hadolint/hadolint",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$"
-    },
-    {
-      "customType": "regex",
-      "description": "Track act version in Makefile",
-      "managerFilePatterns": ["/^Makefile$/"],
-      "matchStrings": [
-        "ACT_VERSION\\s*:=\\s*(?<currentValue>.*?)\\n"
-      ],
-      "depNameTemplate": "nektos/act",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$"
-    },
-    {
-      "customType": "regex",
-      "description": "Track trivy version in Makefile",
-      "managerFilePatterns": ["/^Makefile$/"],
-      "matchStrings": [
-        "TRIVY_VERSION\\s*:=\\s*(?<currentValue>.*?)\\n"
-      ],
-      "depNameTemplate": "aquasecurity/trivy",
-      "datasourceTemplate": "github-releases",
-      "extractVersionTemplate": "^v(?<version>.*)$"
-    },
-    {
-      "customType": "regex",
       "description": "Track tonistiigi/binfmt image version in Makefile",
       "managerFilePatterns": ["/^Makefile$/"],
       "matchStrings": [
         "tonistiigi/binfmt:(?<currentValue>[^\\s]+)"
       ],
       "depNameTemplate": "tonistiigi/binfmt",
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "regex:^qemu-v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$"
     }
   ],
   "packageRules": [
@@ -102,11 +70,31 @@
       "groupName": "Docker dependencies"
     },
     {
-      "description": "Group Makefile tool versions into one PR",
+      "description": "Group mise-managed CLI tools (hadolint, act, trivy, node) and hold each new version 3 days so the aqua:/github-tags backend's upstream GitHub Release assets are published before the bump PR opens (prevents the tag-before-publish 404 on mise install).",
+      "matchManagers": [
+        "mise"
+      ],
+      "groupName": "mise tools",
+      "minimumReleaseAge": "3 days"
+    },
+    {
+      "description": "binfmt is tracked as an image TAG (qemu-vX), not a pullable image ref, so config:best-practices' docker:pinDigests cannot pin a digest onto it — it errors the Pin-dependencies branch on every run. Disable digest pinning for this dep only.",
       "matchManagers": [
         "custom.regex"
       ],
-      "groupName": "Makefile tool versions"
+      "matchDatasources": [
+        "docker"
+      ],
+      "groupName": "binfmt",
+      "pinDigests": false
+    },
+    {
+      "description": "Ignore the project's own builder image — the BUILDER_IMAGE ARG defaults in Dockerfile.runtime/.runtime.local are self-references resolved at build time from the local/CI build, not external deps. Renovate logs 'no-result' lookups for them otherwise.",
+      "matchDepNames": [
+        "ghcr.io/andriykalashnykov/quadmath-cross",
+        "docker.io/andriykalashnykov/quadmath-cross"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Full pass of the portfolio skills against this repo, applying all findings (HIGH/MEDIUM/LOW) with verified, real fixes.

## Toolchain / dependencies
- **mise migration** (BLOCKING /makefile finding): hadolint, act, trivy moved from Makefile `_VERSION` constants + curl-install `deps-*` targets to `.mise.toml` aqua backends. Single `deps-tools` target runs `mise install`; mise shims dir added to the Makefile `PATH`. Verified Renovate's native `mise` manager tracks all four (`node`, hadolint, act, trivy) — no silent un-tracking.
- **Version bumps** (verified current/latest): act `0.2.88→0.2.89`, trivy `0.70.0→0.71.0` (0.71.1 release failed upstream), `actions/checkout` `v6.0.2→v6.0.3`, ubuntu builder base `noble-20260410→noble-20260509.1` (digests verified). These were stuck behind an errored Renovate group (see below).

## CI (`ci.yml`, `cleanup-runs.yml`)
- `jdx/mise-action` added to `docker-image-test` (so `make lint`/`make trivy-fs` get mise-provided hadolint/trivy).
- `dorny/paths-filter`: push-only `base:` (act compatibility, §15e) + `CLAUDE.md` re-included as code (§15c, via `!**/!(CLAUDE).md` — required under the `predicate-quantifier: every` form; picomatch-verified).
- `ci-pass` now `needs` the tag-only `docker-image-builder`/`docker-image-runtime` jobs — a failed release is now visible on the commit status (skipped≠failure keeps PRs green).
- runtime Trivy image scan: `scanners: vuln,secret`.
- `cleanup-runs.yml`: **per-workflow** retention (`group_by(.workflowName)`) replacing a global `.[5:]` that could deregister low-frequency workflows; added a cache-cleanup job.

## Renovate (`renovate.json`)
- Removed the hadolint/act/trivy customManagers (now mise-tracked).
- `platformAutomerge: false` — fixes the red-PR-automerge risk (main has **no required checks**; native auto-merge had nothing to gate on).
- `mise tools` group with `minimumReleaseAge: 3 days` (aqua tag-before-publish 404 race).
- binfmt: `pinDigests: false` (clears the chronically-errored `Pin tonistiigi/binfmt` dashboard branch) + `regex` versioning (makes the `qemu-v*` tag actually trackable).
- Disabled the self-referential `ghcr.io`/`docker.io` builder-image deps (the "no-result" lookup warnings).
- Validated end-to-end with `npx renovate --platform=local` (no validationError; all deps resolve).

## Image hardening
- Runtime image (`Dockerfile.runtime`, `Dockerfile.runtime.local`) now runs as a **non-root** user (UID 10001, `/sbin/nologin`). Binaries are static + world-executable; verified they run as UID 10001.

## Docs
- `README.md` + `CLAUDE.md` re-derived against post-mutation state (self-review-bias guard active): mise tooling, non-root runtime, `deps-tools`, `changes`-filter, gcc-15 backlog re-verified 2026-06-14.

## Verification
- `make lint` (hadolint) and `make trivy-fs` pass via mise shims; `renovate --platform=local` clean; `actionlint` clean; workflow YAML parses; an independent reviewer agent built the runtime image and confirmed all binaries execute as UID 10001. Full `make ci` (builder build + smoke) runs on this PR via `docker-image-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)