### PR TITLE
fix(makefile): guard release target against pre-existing tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,8 @@ ci: deps lint trivy-fs build smoke
 release:
 	@$(eval NT=$(NEWTAG))
 	@echo "$(NT)" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+$$' || { echo "Error: Tag must match vN.N.N"; exit 1; }
+	@if git rev-parse -q --verify "refs/tags/$(NT)" >/dev/null 2>&1; then echo "ERROR: tag $(NT) already exists locally. Pick a new version or delete it: git tag -d $(NT)"; exit 1; fi
+	@if git ls-remote --exit-code --tags origin "refs/tags/$(NT)" >/dev/null 2>&1; then echo "ERROR: tag $(NT) already exists on origin. Pick a new version."; exit 1; fi
 	@git diff --quiet && git diff --cached --quiet || { echo "Error: working tree is dirty; commit or stash changes before releasing."; exit 1; }
 	@echo -n "Are you sure to create and push $(NT) tag? [y/N] " && read ans && [ $${ans:-N} = y ]
 	@echo $(NT) > ./version.txt


### PR DESCRIPTION
The `release` recipe wrote `version.txt`, `git add`, and `git commit` **before** `git tag`, with no check that the tag doesn't already exist. Re-running with an existing tag lands the "Cut vX release" commit but aborts at `git tag`, leaving a dangling commit and a half-published release.

**Fix (Safety Check #16):** add local (`git rev-parse --verify`) + remote (`git ls-remote`) tag pre-existence guards immediately after the semver validation, before any mutation or the confirm prompt.

Verified: `make -n release` parses; running `make release NEWTAG=v0.0.2` (existing tag) errors at the guard before any commit, leaving the tree clean with no new commit/tag.